### PR TITLE
Use @adobe/jwt-auth 0.3.0 or greater

### DIFF
--- a/event-handler/package.json
+++ b/event-handler/package.json
@@ -6,7 +6,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/jwt-auth": "^0.2.0",
+    "@adobe/jwt-auth": "^0.3.0",
     "dotenv": "^8.0.0",
     "node-fetch": "^2.6.0",
     "openwhisk": "^3.19.0"


### PR DESCRIPTION
## Description

I recently released @adobe/jwt-auth 0.3.0 which expires the temporary JWT it creates after 5 minutes. This is a security improvement I hope everyone move to.

## Related Issue

https://github.com/adobe/jwt-auth/issues/23

## Motivation and Context

The JWT token was valid for 24 hours but since we create the bearer token shortly after creating the JWT and the JWT is never re-used it should expire quickly.

## How Has This Been Tested?

Generated an auth token, grabbed the JWT and tried to use it after 5 minutes elapsed time. It was rejected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
